### PR TITLE
Refactor yelp_helper to return entire API request

### DIFF
--- a/lib/sample.rb
+++ b/lib/sample.rb
@@ -1,5 +1,5 @@
 require_relative 'yelp_helper'
-
+require 'pp'
 
 include YelpHelper
 @term = 'dinner'
@@ -11,7 +11,21 @@ include YelpHelper
 # end
 
 @business = get_business('humblebrags-eatery-lakewood')
-puts @business['url']
 
+pp @business # Pretty prints the entire YELP API response
 
-
+# These are the fields we may want to call
+# @business['url']
+# @business['name']
+# @business['hours']
+# @business['display_phone']
+# @business['rating']
+# @business['snippet_text']
+# @business['snippet_image_url']
+# @business['deals']
+# @business['location.display_address'] # Address for this business formatted for display. 
+# ludes all address fields, cross streets and city, state_code, etc.
+# @business['location'] # Location data for this business
+# @business['location.cross_streets'] # Cross streets for this business
+# @business['location.neighborhoods']
+# @business['categories'] # List of category names like: "Breakfast & Brunch", "Bars"

--- a/lib/yelp_helper.rb
+++ b/lib/yelp_helper.rb
@@ -65,11 +65,15 @@ module YelpHelper
     request = Net::HTTP::Get.new uri
     request['Authorization'] = "Bearer #{@token}"
 
-    response = Net::HTTP.start(uri.host, uri.port,
-                               :use_ssl => uri.scheme == 'https') do |http|
-      http.request request
-    end
+    response = Net::HTTP.start(
+      uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
+        http.request request
+      end
+
     @result = JSON.parse(response.body)
-    @business_url = @result.select{|key, hash| key["url"]}
+    #@business_url = @result.select{|key, hash| key["url"]}
+
+    return @result
   end
+
 end


### PR DESCRIPTION
@venetya 
+ I changed the method `get_business` in the **`yelp_helper.rb`** to return the entire YELP API request.
+ I did this because then we can use all the API fields in the view.
+ This also feels more simplified not using `select` and a block. It returns the url key and everything else as well.

---

+ This allows access to fields other than just URL

modified:   lib/sample.rb
modified:   lib/yelp_helper.rb