### PR TITLE
Finish the No Hours issue on places#show page

### DIFF
--- a/app/views/places/index.html.erb
+++ b/app/views/places/index.html.erb
@@ -3,6 +3,7 @@
     <div class="col-lg-8 col-lg-offset-3">
       <div class="well">
         <div class="stop-list-well">
+          <h1>Top Ten Restaurants close by </h1>
           <% if @place.blank? %>
               <h3>No result found</h3>
           <% else %>

--- a/app/views/places/show.html.erb
+++ b/app/views/places/show.html.erb
@@ -11,12 +11,12 @@
   </div>
 
   <div class="col-md-6 business_data">
-    <p>Rating: <%= @rating %> | Price: <%= @price %></p>
-    <p><%= @categories %></p>
-    <p><%= @display_phone %></p>
+    <h3>Rating: <%= @rating %> | Price: <%= @price %> | <%= link_to 'YELP site', "'#{@website}'" %></h3>
+    <h3><%= @categories %></h3>
+    <h3><%= @display_phone %></h3>
 
-    <% if !(@business.include?(@business['name'])) %>
-      <p>No Hours Available</p>
+    <% if @business['hours'] == nil %>
+      <h3>No Hours Available</h3>
     <% else %>
       <div class="time-well">
         <% @hours.each do |day| %>

--- a/lib/sample.rb
+++ b/lib/sample.rb
@@ -110,11 +110,13 @@ end
 # days.each do |d|
 #   week[d['day']] = "hours #{d[:open]}-#{d[:closed]}"
 # end
-
-
-
-pp !(@business3.include?(@business['name']))
-#pp @business3
+pp @business3['hours']
+pp @business.include?(@business['hours'])
+pp @business2['hours']
+pp @business2.include?(@business['hours'])
+#pp @business2.include?(@business['hours'])
+#pp @business3.include?(@business['hours'])
+#pp @business3['url']
 #pp get_business_hours(@business)
 #pp get_business_hours(@business2)
 #pp get_business_hours(@business3)

--- a/lib/yelp_helper.rb
+++ b/lib/yelp_helper.rb
@@ -30,7 +30,7 @@ module YelpHelper
     @term = term || 'dinner'
     @longitude = longitude
     @latitude = latitude
-    @limit = 20
+    @limit = 10
     @result = {}
     @businesses = []
 


### PR DESCRIPTION
+ Added `<% if @business['hours'] == nil %>` in `places#show page
So if the restaurant has no listed hours there will not be an error and the hours will show on the pages that contain hours  
I realized that the previous commit to solve this resulted in no hours ever being shown
+ Added `<h1>Top Ten Restaurants close by </h1>` to index
+ Changed the limit of restaurants show to 10

modified:   app/views/places/index.html.erb
modified:   app/views/places/show.html.erb
modified:   lib/sample.rb
modified:   lib/yelp_helper.rb